### PR TITLE
Refactoring: Move input validators to a single class

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is **Nelosen oppilaat** group's repository for Ohjelmistotuotanto course
 ![UML_Architecture](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/thefakejj/miniprojekti/master/doc/architecture.puml&refresh)
 
 ## Weekly Schedule
+
 * **Monday**
   * 15:30 Retrospective
   * 16:00 Demo A319, Exactum

--- a/src/methods.py
+++ b/src/methods.py
@@ -1,6 +1,7 @@
 from flask import make_response
 from sqlalchemy.sql import text
 from app import db
+from validators import Validate
 import random
 import os
 
@@ -9,35 +10,22 @@ class InvalidInputError(Exception):
 
 def send_book(username, author, title, p_year, publisher, volume, series, address, edition, month, note):
     reftype = "book"
-    if p_year.isalpha():
-        raise InvalidInputError("Vuosi väärin!")
+
+    # validate user input
+    Validate.year(p_year)
+    Validate.username(username)
+    Validate.author(author)
+    Validate.title(title)
+    Validate.publisher(publisher)
+    Validate.volume(volume)
+    Validate.series(series)
+    Validate.address(address)
+    Validate.edition(edition)
+    Validate.note(note)
+    Validate.month(month)
+
     year = int(p_year)
-    if year < 0 or year > 3000:
-        raise InvalidInputError("Vuosi väärin!")
-
     key = generate_key(author,year)
-
-    if len(username) > 100:
-        raise InvalidInputError("Liian pitkä username syöte!")
-    if len(author) > 100:
-        raise InvalidInputError("Liian pitkä author syöte!")
-    if len(title) > 100:
-        raise InvalidInputError("Liian pitkä title syöte!")
-    if len(publisher) > 100:
-        raise InvalidInputError("Liian pitkä publisher syöte!")
-    if len(volume) > 100:
-        raise InvalidInputError("Liian pitkä volume syöte!")
-    if len(series) > 100:
-        raise InvalidInputError("Liian pitkä series syöte!")
-    if len(address) > 100:
-        raise InvalidInputError("Liian pitkä address syöte!")
-    if len(edition) > 100:
-        raise InvalidInputError("Liian pitkä edition syöte!")
-    if len(note) > 100:
-        raise InvalidInputError("Liian pitkä note syöte!")
-    
-    if len(month) > 3:
-        raise InvalidInputError("Syötä kuukausi tyylillä 'jan', 'feb' jne.")
     
     sql = text("INSERT INTO reference (reftype, username, key, author, title, year, publisher, volume, series, address, edition, month, note) VALUES (:reftype, :username, :key, :author, :title, :year, :publisher, :volume, :series, :address, :edition, :month, :note)")
     db.session.execute(sql, {"reftype":reftype, "username":username, "key":key, "author":author, "title":title, "year":year, "publisher":publisher, "volume":volume, "series":series, "address":address, "edition":edition, "month":month, "note":note})

--- a/src/methods.py
+++ b/src/methods.py
@@ -5,9 +5,6 @@ from validators import Validate
 import random
 import os
 
-class InvalidInputError(Exception):
-    pass
-
 def send_book(username, author, title, p_year, publisher, volume, series, address, edition, month, note):
     reftype = "book"
 
@@ -39,33 +36,21 @@ def get_books():
     return books
 
 def send_master(username, author, title, school, p_year, type, address, month, note):
-    reftype = "master"
+    reftype = "master"        
 
-    if p_year.isalpha():
-        raise InvalidInputError("Vuosi väärin!")
+    # validate user input
+    Validate.year(p_year)
+    Validate.username(username)
+    Validate.author(author)
+    Validate.title(title)
+    Validate.school(school)
+    Validate.type(type)
+    Validate.address(address)
+    Validate.note(note)
+    Validate.month(month)
+
     year = int(p_year)
-    if year < 0 or year > 3000:
-        raise InvalidInputError("Vuosi väärin!")
-        
     key = generate_key(author,year)
-
-    if len(username) > 100:
-        raise InvalidInputError("Liian pitkä username syöte!")
-    if len(author) > 100:
-        raise InvalidInputError("Liian pitkä author syöte!")
-    if len(title) > 100:
-        raise InvalidInputError("Liian pitkä title syöte!")
-    if len(school) > 100:
-        raise InvalidInputError("Liian pitkä school syöte!")
-    if len(type) > 100:
-        raise InvalidInputError("Liian pitkä type syöte!")
-    if len(address) > 100:
-        raise InvalidInputError("Liian pitkä address syöte!")
-    if len(note) > 100:
-        raise InvalidInputError("Liian pitkä note syöte!")
-    
-    if len(month) > 3:
-        raise InvalidInputError("Syötä kuukausi tyylillä 'jan', 'feb' jne.")
     
     sql = text("INSERT INTO reference (reftype, username, key, author, title, school, year, type, address, month, note) VALUES (:reftype, :username, :key, :author, :title, :school, :year, :type, :address, :month, :note)")
     db.session.execute(sql, {"reftype":reftype, "username":username, "key":key, "author":author, "title":title, "school":school, "year":year, "type":type, "address":address, "month":month, "note":note})

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,5 +1,6 @@
 from app import app
 from flask import render_template, request, redirect, send_file
+from validators import InvalidInputError
 import methods
 
 
@@ -25,7 +26,7 @@ def send_book():
     try:
         methods.send_book(username,author,title,year,publisher, volume, series, address, edition, month, note)
         return redirect("/")
-    except methods.InvalidInputError as e:
+    except InvalidInputError as e:
         return render_template("error.html", message=str(e))
 
 @app.route("/")
@@ -52,7 +53,7 @@ def send_master():
     try:
         methods.send_master(username, author, title, school, year, type, address, month, note)
         return redirect("/")
-    except methods.InvalidInputError as e:
+    except InvalidInputError as e:
         return render_template("error.html", message=str(e))
 
 @app.route("/keylist", methods=["GET"])

--- a/src/tests/methods_test.py
+++ b/src/tests/methods_test.py
@@ -5,7 +5,7 @@ from app import app
 import sqlite3
 import os
 from db_connection import get_database_connection
-from methods import InvalidInputError
+from validators import InvalidInputError
 
 
 # self.connection = get_database_connection()

--- a/src/validators.py
+++ b/src/validators.py
@@ -1,14 +1,16 @@
-from methods import InvalidInputError
+class InvalidInputError(Exception):
+    pass
 
 # string validation helper class
 class Validate:
-    def string_length(self, input: str, min: int, max: int):
+    @staticmethod
+    def string_length(input: str, min: int, max: int):
         if len(input) < min or len(input) > max:
             return False
         return True
     
     @staticmethod
-    def year(self, input):
+    def year(input):
         if input.isalpha():
             raise InvalidInputError("Vuosi väärin!")
         year = int(input)
@@ -17,62 +19,74 @@ class Validate:
         return True
 
     @staticmethod
-    def username(self, input):
-        if not self.string_length(input, 0, 100):
+    def username(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä username syöte!")
         return True
     
     @staticmethod
-    def author(self, input):
-        if not self.string_length(input, 0, 100):
+    def author(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä author syöte!")
         return True
     
     @staticmethod
-    def title(self, input):
-        if not self.string_length(input, 0, 100):
+    def title(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä title syöte!")
         return True
     
     @staticmethod
-    def publisher(self, input):
-        if not self.string_length(input, 0, 100):
+    def publisher(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä publisher syöte!")
         return True
     
     @staticmethod
-    def volume(self, input):
-        if not self.string_length(input, 0, 100):
+    def volume(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä volume syöte!")
         return True
     
     @staticmethod
-    def series(self, input):
-        if not self.string_length(input, 0, 100):
+    def series(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä series syöte!")
         return True
     
     @staticmethod
-    def address(self, input):
-        if not self.string_length(input, 0, 100):
+    def address(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä address syöte!")
         return True
     
     @staticmethod
-    def edition(self, input):
-        if not self.string_length(input, 0, 100):
+    def edition(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä edition syöte!")
         return True
     
     @staticmethod
-    def note(self, input):
-        if not self.string_length(input, 0, 100):
+    def note(input):
+        if not Validate.string_length(input, 0, 100):
             raise InvalidInputError("Liian pitkä note syöte!")
         return True
     
     @staticmethod
-    def month(self, input):
-        if not self.string_length(input, 0, 3):
+    def month(input):
+        if not Validate.string_length(input, 0, 3):
             raise InvalidInputError("Syötä kuukausi tyylillä 'jan', 'feb' jne.")
+        return True
+    
+    @staticmethod
+    def school(input):
+        if not Validate.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä school syöte!")
+        return True
+
+    @staticmethod
+    def type(input):
+        if not Validate.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä type syöte!")
         return True
     

--- a/src/validators.py
+++ b/src/validators.py
@@ -1,0 +1,78 @@
+from methods import InvalidInputError
+
+# string validation helper class
+class Validate:
+    def string_length(self, input: str, min: int, max: int):
+        if len(input) < min or len(input) > max:
+            return False
+        return True
+    
+    @staticmethod
+    def year(self, input):
+        if input.isalpha():
+            raise InvalidInputError("Vuosi väärin!")
+        year = int(input)
+        if year < 0 or year > 3000:
+            raise InvalidInputError("Vuosi väärin!")
+        return True
+
+    @staticmethod
+    def username(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä username syöte!")
+        return True
+    
+    @staticmethod
+    def author(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä author syöte!")
+        return True
+    
+    @staticmethod
+    def title(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä title syöte!")
+        return True
+    
+    @staticmethod
+    def publisher(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä publisher syöte!")
+        return True
+    
+    @staticmethod
+    def volume(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä volume syöte!")
+        return True
+    
+    @staticmethod
+    def series(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä series syöte!")
+        return True
+    
+    @staticmethod
+    def address(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä address syöte!")
+        return True
+    
+    @staticmethod
+    def edition(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä edition syöte!")
+        return True
+    
+    @staticmethod
+    def note(self, input):
+        if not self.string_length(input, 0, 100):
+            raise InvalidInputError("Liian pitkä note syöte!")
+        return True
+    
+    @staticmethod
+    def month(self, input):
+        if not self.string_length(input, 0, 3):
+            raise InvalidInputError("Syötä kuukausi tyylillä 'jan', 'feb' jne.")
+        return True
+    


### PR DESCRIPTION
## OHTU Week 6 Exercise 6:

### Changes in this pull-request:

- Moved all string validators in `src/methods.py` into a single class `Validate()` in `src/validators.py`. This allows easy re-use of the validator methods later on if necessary.

- Moved the declaration for `InvalidInputError()` to the `src/validators.py` file.

- Created validators for all existing test cases. All methods raise a `InvalidInputError()` if validation fails.

- Added one empty line to create a change in branch (first part of exercise 6).

### Test Passing

Tests are passing 100% after the changes.